### PR TITLE
Use pcre2 on FreeBSD

### DIFF
--- a/hastysite.nims
+++ b/hastysite.nims
@@ -19,6 +19,8 @@ if findExe("musl-gcc") != "":
 
 when defined(windows):
   switch("dynlibOverride", "pcre64")
+when defined(freebsd):
+  switch("dynlibOverride", "pcre2")
 else:
   switch("dynlibOverride", "pcre")
 


### PR DESCRIPTION
First, thanks for this static site generator in nim!

FreeBSD have two versions of PCRE in package (pcre: 8.45 and pcre2: 10.39).

In order to build hastysite, I have to use pcre2, otherwise I get linker errors like this:
```
/usr/local/bin/x86_64-unknown-freebsd13.0-ld: /home/xxx/.cache/nim/hastysite_r/stdlib_nre.nim.c.o: in function `replace__impureZnre_5941':
stdlib_nre.nim.c:(.text+0x48ae): undefined reference to `pcre_config'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

